### PR TITLE
My article

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,7 +9,7 @@
 }
 
 .calendar-container {
-  display: flex;
+  display: grid;
   justify-content: center;
   align-items: flex-start;
   width: 250px;

--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,6 @@
 .app-container {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(3, 1fr);
-  grid-column-gap: 10px;
-  grid-row-gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   align-items: center;
   margin-top: 50px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,9 @@
 .app-container {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  grid-column-gap: 10px;
+  grid-row-gap: 10px;
   align-items: center;
   margin-top: 50px;
 }


### PR DESCRIPTION
Anteriormente, utilizaba "display: flex" para la cuadricula de los elementos. Ahora usa "display: grid" para que tengamos más control de los que ocupa los elementos.