### PR TITLE
Mejore el css con css grid al fichero index.css

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,45 +1,51 @@
 body {
-    margin: 0;
-    padding: 0;
-    font-family: Arial, sans-serif;
-  }
-  
-  .app {
-    background-color: #f5f5f5;
-  }
-  
-  .app-container {
-    display: flex;
-  }
-  
-  header {
-    background-color: #333;
-    color: #fff;
-    padding: 20px;
-  }
-  
-  header h1 {
-    margin: 0;
-  }
-  
-  aside {
-    background-color: #eee;
-    width: 200px;
-    padding: 20px;
-  }
-  
-  aside ul {
-    list-style: none;
-    padding: 0;
-  }
-  
-  aside li {
-    margin-bottom: 10px;
-    cursor: pointer;
-  }
-  
-  main {
-    flex: 1;
-    padding: 20px;
-  }
-  
+  margin: 0;
+  padding: 0;
+  font-family: Arial, sans-serif;
+}
+
+.app {
+  background-color: #f5f5f5;
+}
+
+.app-container {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+      "header header"
+      "aside main";
+  height: 100vh; /* Asegura que la cuadrícula ocupe toda la altura de la ventana */
+}
+
+header {
+  grid-area: header;
+  background-color: #333;
+  color: #fff;
+  padding: 20px;
+}
+
+header h1 {
+  margin: 0;
+}
+
+aside {
+  grid-area: aside;
+  background-color: #eee;
+  padding: 20px;
+}
+
+aside ul {
+  list-style: none;
+  padding: 0;
+}
+
+aside li {
+  margin-bottom: 10px;
+  cursor: pointer;
+}
+
+main {
+  grid-area: main;
+  padding: 20px;
+}


### PR DESCRIPTION
Cambié el diseño para usar CSS Grid, que organiza todo en una tabla invisible con dos columnas (barra lateral y contenido principal) y dos filas (encabezado y contenido). Usé display: grid en .app-container para definir esta estructura.  Aunque antes ya estaban, le di nombres a las partes del diseño usando grid-template-areas: header para el encabezado, aside para la barra lateral y main para el contenido principal. La barra lateral ocupa una columna fija de 200px, mientras que el contenido principal usa todo el espacio restante con 1fr.